### PR TITLE
Adjust weather job secret handling for optional WorldTides key

### DIFF
--- a/scripts/weather_job.py
+++ b/scripts/weather_job.py
@@ -54,9 +54,24 @@ def collect_weather_data(location_name: str = "AGI", forecast_hours: int = 24, m
     now = datetime.now()
     end_date = now + timedelta(hours=forecast_hours)
 
-    required_secrets = ["STORMGLASS_API_KEY", "WORLDTIDES_API_KEY"]
-    missing_secrets = [key for key in required_secrets if not os.getenv(key)]
-    resolved_mode, offline_reasons = decide_execution_mode(mode, missing_secrets, NCMSeleniumIngestor is not None)
+    mandatory_secrets = ["STORMGLASS_API_KEY"]
+    optional_secrets = ["WORLDTIDES_API_KEY"]
+
+    missing_mandatory = [key for key in mandatory_secrets if not os.getenv(key)]
+    missing_optional = [key for key in optional_secrets if not os.getenv(key)]
+
+    resolved_mode, offline_reasons = decide_execution_mode(
+        mode,
+        missing_mandatory,
+        NCMSeleniumIngestor is not None,
+    )
+
+    if missing_optional:
+        print(
+            "ℹ️ 선택 시크릿 누락: "
+            + ", ".join(missing_optional)
+            + " (실제 데이터 수집은 계속 진행됩니다)"
+        )
 
     if resolved_mode == "offline":
         synthetic_series, statuses = generate_offline_dataset(location_name, forecast_hours)


### PR DESCRIPTION
## Summary
- keep WorldTides marked as optional when determining execution mode for the weather job
- surface a note when optional secrets are missing while allowing online collection to proceed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6297aee84832789cd79f2a7ecd459